### PR TITLE
I've updated the `curl` and `clap` dependencies to their latest versi…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ license = "GPLv3"
 license-file = "LICENSE.txt"
 
 [dependencies]
-curl = "0.4.43"
-clap = { version = "3.2.8", features = ["derive"] }
+curl = "0.4.47"
+clap = { version = "4.5.38", features = ["derive"] }


### PR DESCRIPTION
…ons.

- `curl` has been updated from 0.4.43 to 0.4.47.
- `clap` has been updated from 3.2.8 to 4.5.38.

With these new versions, your project builds and tests successfully.